### PR TITLE
Remove vis dependency

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -85,7 +85,8 @@
     "readme": "https://github.com/inventwo/ioBroker.vis-icontwo/blob/master/README.md",
     "loglevel": "info",
     "restartAdapters": [
-      "vis"
+      "vis",
+      "vis-2"
     ],
     "singleton": true,
     "localLink": "http://icontwo.inventwo.com/",
@@ -108,9 +109,7 @@
     "dependencies": [
       {
         "js-controller": ">=3.1.0"
-      },
-      "vis"
-    ]
+      }    ]
   },
   "native": {},
   "objects": [],


### PR DESCRIPTION
vis dependency is not required and would block usage of vis-2 as only visualization adapter.
So vis should be removed from dependencies.

vis-2 shoul dbe added to list of adapters requiring a restart.